### PR TITLE
Add minimal RAG MVP with FastAPI and Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# Rag-demo
+# RAG Demo
+
+Minimal local Retrieval-Augmented Generation app.
+
+## Architecture
+
+- **Backend**: FastAPI service with OpenAI embeddings and FAISS index.
+- **Frontend**: Next.js page for uploading PDFs and asking questions.
+
+## Running
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # set OPENAI_API_KEY
+uvicorn app:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+pnpm i
+pnpm dev
+```
+
+Open <http://localhost:3000> and ensure backend at <http://localhost:8000>.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_key_here

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,48 @@
+# Backend
+
+Simple FastAPI service for PDF question answering.
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env  # set OPENAI_API_KEY=...
+```
+
+## Running
+
+```bash
+uvicorn app:app --reload
+```
+
+## Seeding sample data
+
+```bash
+make seed
+```
+
+## Endpoints
+
+### `POST /upload`
+Upload one or more PDFs.
+
+```bash
+curl -F "files=@path/to/file.pdf" http://localhost:8000/upload
+```
+
+### `GET /sources`
+List indexed documents.
+
+```bash
+curl http://localhost:8000/sources
+```
+
+### `POST /query`
+Ask a question.
+
+```bash
+curl -H 'Content-Type: application/json' \
+  -d '{"question": "What is in the PDF?", "docIds": ["<doc_id>"]}' \
+  http://localhost:8000/query
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,46 @@
+"""FastAPI application exposing RAG endpoints."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+from models.schemas import Citation, Doc, QueryRequest, QueryResponse, UploadResponse
+from rag import pipeline, storage
+
+app = FastAPI(title="RAG MVP")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/upload", response_model=UploadResponse)
+async def upload(files: List[UploadFile] = File(...)) -> UploadResponse:
+    """Upload PDF files and rebuild the index."""
+
+    docs = storage.save_uploads(files)
+    pipeline.rebuild_index()
+    return UploadResponse(docs=[Doc(id=d["id"], title=d["title"]) for d in docs])
+
+
+@app.get("/sources", response_model=UploadResponse)
+async def sources() -> UploadResponse:
+    """List indexed documents."""
+
+    docs = storage.get_docs()
+    return UploadResponse(docs=[Doc(id=d["id"], title=d["title"]) for d in docs])
+
+
+@app.post("/query", response_model=QueryResponse)
+async def query(body: QueryRequest) -> QueryResponse:
+    """Answer a question with optional document filtering."""
+
+    res = pipeline.query(body.question, body.docIds)
+    citations = [Citation(**c) for c in res["citations"]]
+    return QueryResponse(answer=res["answer"], citations=citations)

--- a/backend/makefile
+++ b/backend/makefile
@@ -1,0 +1,5 @@
+run:
+uvicorn app:app --reload
+
+seed:
+python seed.py

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+"""Pydantic models for API requests and responses."""
+
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class Doc(BaseModel):
+    """Metadata for a single document."""
+
+    id: str
+    title: str
+
+
+class UploadResponse(BaseModel):
+    """Response after uploading documents."""
+
+    docs: List[Doc]
+
+
+class QueryRequest(BaseModel):
+    """Question request body."""
+
+    question: str
+    docIds: Optional[List[str]] = None
+
+
+class Citation(BaseModel):
+    """A snippet referenced in the answer."""
+
+    docId: str
+    page: int
+    text: str
+
+
+class QueryResponse(BaseModel):
+    """Answer with supporting citations."""
+
+    answer: str
+    citations: List[Citation]

--- a/backend/rag/pipeline.py
+++ b/backend/rag/pipeline.py
@@ -1,0 +1,90 @@
+"""Chunking, embedding, index build/load, and querying."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from langchain.docstore.document import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import FAISS
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from pypdf import PdfReader
+
+from . import storage
+
+
+def _pdf_to_documents(path: str, doc_id: str, title: str) -> List[Document]:
+    """Load a PDF and split into LangChain Documents."""
+
+    reader = PdfReader(path)
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=storage.CHUNK_SIZE, chunk_overlap=storage.CHUNK_OVERLAP
+    )
+    docs: List[Document] = []
+    for page_num, page in enumerate(reader.pages, start=1):
+        text = page.extract_text() or ""
+        for chunk in splitter.split_text(text):
+            docs.append(
+                Document(page_content=chunk, metadata={"doc_id": doc_id, "title": title, "page": page_num})
+            )
+    return docs
+
+
+def rebuild_index() -> None:
+    """Recreate the FAISS index from all stored PDFs."""
+
+    docs_meta = storage.get_docs()
+    all_docs: List[Document] = []
+    for meta in docs_meta:
+        all_docs.extend(_pdf_to_documents(meta["path"], meta["id"], meta["title"]))
+    if not all_docs:
+        return
+    embeddings = OpenAIEmbeddings()  # TODO: switch to OSS embeddings
+    index = FAISS.from_documents(all_docs, embeddings)
+    index.save_local(str(storage.INDEX_DIR))
+
+
+def _get_retriever(doc_ids: Optional[List[str]] = None):
+    """Create a retriever that optionally filters by doc IDs."""
+
+    embeddings = OpenAIEmbeddings()
+    index = FAISS.load_local(str(storage.INDEX_DIR), embeddings, allow_dangerous_deserialization=True)
+
+    def _filter_docs(query: str) -> List[Document]:
+        docs = index.similarity_search(query, k=5)
+        if doc_ids:
+            docs = [d for d in docs if d.metadata.get("doc_id") in doc_ids]
+        return docs
+
+    class _Retriever:
+        def get_relevant_documents(self, query: str) -> List[Document]:
+            return _filter_docs(query)
+
+    return _Retriever()
+
+
+def query(question: str, doc_ids: Optional[List[str]] = None) -> dict:
+    """Run retrieval QA and return answer plus citations."""
+
+    if not storage.INDEX_DIR.exists():
+        return {"answer": "No documents indexed.", "citations": []}
+
+    retriever = _get_retriever(doc_ids)
+    llm = ChatOpenAI()
+    from langchain.chains import RetrievalQA
+
+    qa = RetrievalQA.from_chain_type(
+        llm=llm, retriever=retriever, return_source_documents=True
+    )
+    res = qa.invoke({"query": question})
+    sources: List[Document] = res.get("source_documents", [])
+    citations = [
+        {"docId": d.metadata["doc_id"], "page": d.metadata["page"], "text": d.page_content}
+        for d in sources
+    ]
+    answer = res.get("result", "")
+    if not answer:
+        answer = "No relevant information found."
+    if not citations:
+        answer = "No relevant information found."
+    return {"answer": answer, "citations": citations}

--- a/backend/rag/storage.py
+++ b/backend/rag/storage.py
@@ -1,0 +1,85 @@
+"""Local file and index management."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Dict, List
+
+from fastapi import UploadFile
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DOCS_DIR = DATA_DIR / "docs"
+INDEX_DIR = DATA_DIR / "faiss"
+METADATA_FILE = DATA_DIR / "docs.json"
+
+CHUNK_SIZE = 800  # TODO: tune chunk size
+CHUNK_OVERLAP = 200  # TODO: tune overlap
+
+
+def init_storage() -> None:
+    """Ensure required directories exist."""
+
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    INDEX_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def load_metadata() -> List[Dict]:
+    """Load document metadata from disk."""
+
+    if METADATA_FILE.exists():
+        return json.loads(METADATA_FILE.read_text())
+    return []
+
+
+def save_metadata(docs: List[Dict]) -> None:
+    """Persist document metadata to disk."""
+
+    METADATA_FILE.write_text(json.dumps(docs, indent=2))
+
+
+def _unique_title(base: str, existing: List[str]) -> str:
+    """Append numeric suffix until title is unique."""
+
+    if base not in existing:
+        return base
+    idx = 1
+    while f"{base}_{idx}" in existing:
+        idx += 1
+    return f"{base}_{idx}"
+
+
+def save_uploads(files: List[UploadFile]) -> List[Dict]:
+    """Store uploaded PDFs and update metadata.
+
+    Returns metadata for all documents (including previous ones).
+    """
+
+    init_storage()
+    docs = load_metadata()
+    titles = [d["title"] for d in docs]
+    batch_titles: List[str] = []
+
+    for file in files:
+        base = Path(file.filename).stem
+        if base in titles:
+            # Re-upload: overwrite existing file
+            doc = next(d for d in docs if d["title"] == base)
+        else:
+            title = _unique_title(base, titles + batch_titles)
+            doc = {"id": str(uuid.uuid4()), "title": title, "path": str(DOCS_DIR / f"{title}.pdf")}
+            docs.append(doc)
+            titles.append(title)
+        with open(doc["path"], "wb") as f:
+            f.write(file.file.read())
+        batch_titles.append(doc["title"])
+
+    save_metadata(docs)
+    return docs
+
+
+def get_docs() -> List[Dict]:
+    """Return list of stored documents."""
+
+    return load_metadata()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+langchain
+langchain-community
+langchain-openai
+faiss-cpu
+pypdf
+python-multipart

--- a/backend/sample_data/sample.pdf
+++ b/backend/sample_data/sample.pdf
@@ -1,0 +1,36 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 12 Tf
+72 72 Td
+(Hello PDF) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000063 00000 n 
+0000000112 00000 n 
+0000000279 00000 n 
+0000000370 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+432
+%%EOF

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,19 @@
+"""Seed the vector index with the sample PDF."""
+
+from pathlib import Path
+from fastapi import UploadFile
+
+from rag import pipeline, storage
+
+
+def main() -> None:
+    path = Path("sample_data/sample.pdf")
+    with path.open("rb") as f:
+        upload = UploadFile(filename=path.name, file=f)
+        storage.save_uploads([upload])
+    pipeline.rebuild_index()
+    print("Indexed sample.pdf")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,15 @@
+# Frontend
+
+Minimal Next.js interface.
+
+## Setup
+
+```bash
+pnpm i
+```
+
+## Running
+
+```bash
+pnpm dev
+```

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -1,0 +1,22 @@
+const API_BASE = 'http://localhost:8000';
+
+export async function uploadFiles(files: File[]) {
+  const form = new FormData();
+  files.forEach(f => form.append('files', f));
+  const res = await fetch(`${API_BASE}/upload`, { method: 'POST', body: form });
+  return res.json();
+}
+
+export async function getSources() {
+  const res = await fetch(`${API_BASE}/sources`);
+  return res.json();
+}
+
+export async function ask(question: string, docIds: string[]) {
+  const res = await fetch(`${API_BASE}/query`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question, docIds }),
+  });
+  return res.json();
+}

--- a/frontend/app/components/QueryBox.tsx
+++ b/frontend/app/components/QueryBox.tsx
@@ -1,0 +1,28 @@
+'use client';
+import React, { useState } from 'react';
+import { ask } from '../api';
+
+interface Props {
+  docIds: string[];
+  onAnswer: (res: any) => void;
+}
+
+export default function QueryBox({ docIds, onAnswer }: Props) {
+  const [question, setQuestion] = useState('');
+  const submit = async () => {
+    const res = await ask(question, docIds);
+    onAnswer(res);
+  };
+  return (
+    <div className="my-2">
+      <input
+        value={question}
+        onChange={e => setQuestion(e.target.value)}
+        className="border p-1 mr-2"
+      />
+      <button onClick={submit} className="px-2 py-1 bg-blue-500 text-white">
+        Ask
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/components/Result.tsx
+++ b/frontend/app/components/Result.tsx
@@ -1,0 +1,26 @@
+'use client';
+import React from 'react';
+
+interface Citation { docId: string; page: number; text: string }
+
+interface Props {
+  answer: string;
+  citations: Citation[];
+}
+
+export default function Result({ answer, citations }: Props) {
+  if (!answer) return null;
+  return (
+    <div className="my-4">
+      <p>{answer}</p>
+      {citations.map((c, i) => (
+        <details key={i} className="my-2">
+          <summary>
+            {c.docId} p.{c.page}
+          </summary>
+          <p className="ml-4">{c.text}</p>
+        </details>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/components/Sources.tsx
+++ b/frontend/app/components/Sources.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+interface Doc { id: string; title: string }
+
+interface Props {
+  docs: Doc[];
+  selected: string[];
+  toggle: (id: string) => void;
+}
+
+export default function Sources({ docs, selected, toggle }: Props) {
+  return (
+    <div className="my-2">
+      {docs.map(d => (
+        <label key={d.id} className="block">
+          <input
+            type="checkbox"
+            checked={selected.includes(d.id)}
+            onChange={() => toggle(d.id)}
+          />{' '}
+          {d.title}
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/frontend/app/components/Upload.tsx
+++ b/frontend/app/components/Upload.tsx
@@ -1,0 +1,12 @@
+'use client';
+import React from 'react';
+import { uploadFiles } from '../api';
+
+export default function Upload({ onUploaded }: { onUploaded: () => void }) {
+  const handle = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+    await uploadFiles(Array.from(e.target.files));
+    onUploaded();
+  };
+  return <input type="file" multiple onChange={handle} className="my-2" />;
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,12 @@
+import './globals.css';
+import React from 'react';
+
+export const metadata = { title: 'RAG MVP' };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="container mx-auto">{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import Upload from './components/Upload';
+import Sources from './components/Sources';
+import QueryBox from './components/QueryBox';
+import Result from './components/Result';
+import { getSources } from './api';
+
+interface Doc { id: string; title: string }
+
+export default function Page() {
+  const [docs, setDocs] = useState<Doc[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [result, setResult] = useState<{ answer: string; citations: any[] }>({
+    answer: '',
+    citations: [],
+  });
+
+  const load = async () => {
+    const data = await getSources();
+    setDocs(data.docs || []);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const toggle = (id: string) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <main className="p-4">
+      <Upload onUploaded={load} />
+      <Sources docs={docs} selected={selected} toggle={toggle} />
+      <QueryBox docIds={selected} onAnswer={setResult} />
+      <Result answer={result.answer} citations={result.citations} />
+    </main>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rag-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.0",
+    "tailwindcss": "3.4.1",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.14"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "preserve",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build FastAPI backend supporting PDF upload, source listing, and question answering over FAISS index
- add local storage utilities, sample seed script, and project docs
- scaffold Next.js front end with upload, source selection, and querying UI

## Testing
- `python -m py_compile backend/app.py backend/rag/pipeline.py backend/rag/storage.py backend/models/schemas.py backend/seed.py`
- `cd frontend && npx tsc --noEmit` *(fails: Cannot find module 'react' ...)*

------
https://chatgpt.com/codex/tasks/task_b_689614b368c08328adfd6f104f3cf64d